### PR TITLE
fix the ability to run programs with more than one kernel

### DIFF
--- a/lib/CL/devices/vortex/pocl-vortex.c
+++ b/lib/CL/devices/vortex/pocl-vortex.c
@@ -575,21 +575,26 @@ void pocl_vortex_run (void *data, _cl_command_node *cmd) {
   // release argument host buffer
   free(host_kargs_base_ptr);
 
+  // release previous kernel buffer
+  if (dd->vx_kernel_buffer != NULL)
+  {
+    vx_mem_free(dd->vx_kernel_buffer);
+    dd->vx_kernel_buffer = NULL;
+  }
+
   // upload kernel to device
-  if (NULL == dd->vx_kernel_buffer) {
-    char sz_program_bc[POCL_MAX_PATHNAME_LENGTH];
-    char sz_program_vxbin[POCL_MAX_PATHNAME_LENGTH];
+  char sz_program_bc[POCL_MAX_PATHNAME_LENGTH];
+  char sz_program_vxbin[POCL_MAX_PATHNAME_LENGTH];
 
-    pocl_cache_program_bc_path(sz_program_bc, program, device_i);
-    remove_extension(sz_program_bc);
+  pocl_cache_program_bc_path(sz_program_bc, program, device_i);
+  remove_extension(sz_program_bc);
 
-    strcpy(sz_program_vxbin, sz_program_bc);
-    strncat(sz_program_vxbin, ".vxbin", POCL_MAX_PATHNAME_LENGTH - 1);
-
-    vx_err = vx_upload_kernel_file(dd->vx_device, sz_program_vxbin, &dd->vx_kernel_buffer);
-    if (vx_err != 0) {
-      POCL_ABORT("POCL_VORTEX_RUN\n");
-    }
+  strcpy(sz_program_vxbin, sz_program_bc);
+  strncat(sz_program_vxbin, ".vxbin", POCL_MAX_PATHNAME_LENGTH - 1);
+  
+  vx_err = vx_upload_kernel_file(dd->vx_device, sz_program_vxbin, &dd->vx_kernel_buffer);
+  if (vx_err != 0) {
+    POCL_ABORT("POCL_VORTEX_RUN\n");
   }
 
   // launch kernel execution

--- a/lib/CL/devices/vortex/pocl-vortex.c
+++ b/lib/CL/devices/vortex/pocl-vortex.c
@@ -578,6 +578,7 @@ void pocl_vortex_run (void *data, _cl_command_node *cmd) {
   // release previous kernel buffer
   if (dd->vx_kernel_buffer != NULL)
   {
+    vx_dump_perf(dd->vx_device, stdout);
     vx_mem_free(dd->vx_kernel_buffer);
     dd->vx_kernel_buffer = NULL;
   }


### PR DESCRIPTION
Hello, while working with Vortex I encountered a problem: when kernels beyond the first are scheduled for execution, instead of running their own code, the first kernel’s code is executed but with the arguments of the other kernels, which leads to unexpected program behavior.

To demonstrate the problem, I wrote a small [test](https://github.com/talubik/vortex/blob/talubik/vortex/tests/opencl/twokernels/main.cpp) .
Program output: 
<img width="262" height="56" alt="output1" src="https://github.com/user-attachments/assets/676582f0-a490-47e9-8ea4-909a68aa150d" />
This fix resolves this bug, and here is the program output after applying the change:
<img width="264" height="54" alt="output2" src="https://github.com/user-attachments/assets/a89363e7-a2f9-4db1-ba4d-49188c49f915" />


